### PR TITLE
Add offline browser coverage for the Earthquake Atlas

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -20,4 +20,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:browser
       - run: npm audit --audit-level=low

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,10 @@ typings/
 .nuxt
 dist
 
+# Playwright output
+playwright-report/
+test-results/
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and *not* Next.js

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Parcel prints the local development URL after it starts.
 | `npm run format:check` | Check source, workflow, data metadata, tests, and docs.        |
 | `npm run test:unit`    | Test data, evidence, filtering, and HTML contracts.            |
 | `npm run test:dist`    | Verify the generated data and JavaScript assets.               |
+| `npm run test:browser` | Exercise the built Atlas against offline browser fixtures.     |
 | `npm test`             | Run formatting, unit tests, build, and artifact checks.        |
 
 Refreshing the snapshot is an intentional source update. Review both generated
@@ -110,6 +111,14 @@ git diff -- static/data/significant_month.geojson static/data/significant_month.
 For a dependency-security check, run `npm audit --audit-level=low` after
 `npm ci`.
 
+Browser tests intercept the live USGS feed and external basemap with committed,
+offline fixtures. They start a local server on port 4173 by default; use one
+shared override when that port is occupied:
+
+```sh
+ATLAS_TEST_PORT=44173 npm run test:browser
+```
+
 ## Project structure
 
 ```text
@@ -121,7 +130,7 @@ For a dependency-security check, run `npm audit --audit-level=low` after
 ├── static/js/app.js                  # MapLibre runtime and UI interactions
 ├── static/js/earthquake-data.js      # Pure data and evidence contracts
 ├── static/scss/app.scss              # Full-screen responsive presentation
-├── tests/                            # Data, HTML, and built-artifact contracts
+├── tests/                            # Unit, artifact, and offline browser contracts
 ├── THIRD_PARTY_DATA.md               # Dataset provenance and licensing
 └── .github/workflows/api.yml         # Install, test, build, and audit checks
 ```
@@ -150,7 +159,7 @@ decision.
 
 ## Roadmap
 
-- Add browser automation for map selection, empty filters, and fallback mode.
+- Extend browser coverage to clustered map selection and layer visibility.
 - Add ShakeMap intensity products as a separately sourced observed-data layer.
 - Keep any future hypothetical earthquake and response-agent experience in a
   separately labeled Signal Room simulation rather than mixing it with this

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@parcel/transformer-raw": "^2.16.4",
         "@parcel/transformer-sass": "^2.16.4",
         "@parcel/transformer-webmanifest": "^2.16.4",
+        "@playwright/test": "1.62.1",
         "parcel": "2.16.4",
         "prettier": "3.9.6",
         "sass": "1.102.0"
@@ -2669,6 +2670,22 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.15.47",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
@@ -3162,6 +3179,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/gl-matrix": {
@@ -3907,6 +3939,38 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && parcel build index.html --dist-dir dist --public-url ./ --no-cache",
     "format:check": "prettier --check README.md THIRD_PARTY_DATA.md docs/*.md .github/workflows/api.yml index.html wdc-usga-gov.html static/js/app.js static/js/earthquake-data.js static/scss/app.scss scripts/*.mjs playwright.config.mjs tests/*.test.mjs tests/browser/*.test.mjs tests/fixtures/*.md tests/support/*.mjs && prettier --check .parcelrc static/data/significant_month.meta.json tests/fixtures/*.geojson --parser json",
     "data:refresh": "node scripts/refresh-usgs-snapshot.mjs",
-    "test:unit": "node --test tests/earthquake-data.test.mjs tests/index-contract.test.mjs",
+    "test:unit": "node --test tests/earthquake-data.test.mjs tests/index-contract.test.mjs tests/test-server.test.mjs",
     "test:dist": "node --test tests/dist-contract.test.mjs",
     "test:browser": "playwright test",
     "test": "npm run format:check && npm run test:unit && npm run build && npm run test:dist"

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
   "scripts": {
     "dev": "parcel index.html",
     "build": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\" && parcel build index.html --dist-dir dist --public-url ./ --no-cache",
-    "format:check": "prettier --check README.md THIRD_PARTY_DATA.md docs/*.md .github/workflows/api.yml index.html wdc-usga-gov.html static/js/app.js static/js/earthquake-data.js static/scss/app.scss scripts/*.mjs tests/*.test.mjs && prettier --check .parcelrc static/data/significant_month.meta.json --parser json",
+    "format:check": "prettier --check README.md THIRD_PARTY_DATA.md docs/*.md .github/workflows/api.yml index.html wdc-usga-gov.html static/js/app.js static/js/earthquake-data.js static/scss/app.scss scripts/*.mjs playwright.config.mjs tests/*.test.mjs tests/browser/*.test.mjs tests/fixtures/*.md tests/support/*.mjs && prettier --check .parcelrc static/data/significant_month.meta.json tests/fixtures/*.geojson --parser json",
     "data:refresh": "node scripts/refresh-usgs-snapshot.mjs",
     "test:unit": "node --test tests/earthquake-data.test.mjs tests/index-contract.test.mjs",
     "test:dist": "node --test tests/dist-contract.test.mjs",
+    "test:browser": "playwright test",
     "test": "npm run format:check && npm run test:unit && npm run build && npm run test:dist"
   },
   "keywords": [
@@ -36,6 +37,7 @@
     "@parcel/transformer-raw": "^2.16.4",
     "@parcel/transformer-sass": "^2.16.4",
     "@parcel/transformer-webmanifest": "^2.16.4",
+    "@playwright/test": "1.62.1",
     "parcel": "2.16.4",
     "prettier": "3.9.6",
     "sass": "1.102.0"

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from '@playwright/test';
 
-const port = 4173;
-const baseURL = `http://127.0.0.1:${port}`;
+import { atlasTestOrigin } from './tests/support/test-server.mjs';
 
 export default defineConfig({
   testDir: './tests/browser',
@@ -12,7 +11,7 @@ export default defineConfig({
   expect: { timeout: 5_000 },
   reporter: process.env.CI ? 'line' : 'list',
   use: {
-    baseURL,
+    baseURL: atlasTestOrigin,
     browserName: 'chromium',
     headless: true,
     locale: 'en-US',
@@ -25,7 +24,7 @@ export default defineConfig({
   },
   webServer: {
     command: 'node tests/support/serve-dist.mjs',
-    url: baseURL,
+    url: atlasTestOrigin,
     reuseExistingServer: false,
     timeout: 10_000,
   },

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,32 @@
+import { defineConfig } from '@playwright/test';
+
+const port = 4173;
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: './tests/browser',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 15_000,
+  expect: { timeout: 5_000 },
+  reporter: process.env.CI ? 'line' : 'list',
+  use: {
+    baseURL,
+    browserName: 'chromium',
+    headless: true,
+    locale: 'en-US',
+    timezoneId: 'UTC',
+    reducedMotion: 'reduce',
+    serviceWorkers: 'block',
+    viewport: { width: 1440, height: 1000 },
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'node tests/support/serve-dist.mjs',
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 10_000,
+  },
+});

--- a/tests/browser/atlas.test.mjs
+++ b/tests/browser/atlas.test.mjs
@@ -26,6 +26,31 @@ test('selecting a fixture event opens its observed-event detail', async ({
   browser.assertClean();
 });
 
+test('refreshing an open event replaces stale details for the same USGS id', async ({
+  page,
+}) => {
+  const browser = await openAtlas(page, {
+    liveFeed: 'revised-on-refresh',
+  });
+
+  await page
+    .locator('#event-list button', { hasText: 'Browser Fixture Ridge' })
+    .click();
+  await expect(page.locator('#event-detail-title')).toHaveText(
+    'Browser Fixture Ridge'
+  );
+
+  await page.locator('#refresh-data').click();
+
+  await expect(page.locator('#event-detail-title')).toHaveText(
+    'Revised Browser Fixture Ridge'
+  );
+  await expect(page.locator('#detail-magnitude')).toHaveText('M6.7');
+  await expect(page.locator('#detail-felt')).toHaveText('84');
+  expect(browser.liveRequestCount).toBe(2);
+  browser.assertClean();
+});
+
 test('a filter with no matching observations renders an explicit empty state', async ({
   page,
 }) => {

--- a/tests/browser/atlas.test.mjs
+++ b/tests/browser/atlas.test.mjs
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+
+import { openAtlas } from '../support/atlas-page.mjs';
+
+test('selecting a fixture event opens its observed-event detail', async ({
+  page,
+}) => {
+  const browser = await openAtlas(page);
+
+  await page
+    .locator('#event-list button', { hasText: 'Browser Fixture Ridge' })
+    .click();
+
+  const detail = page.locator('#event-detail');
+  await expect(detail).toBeVisible();
+  await expect(detail.getByText('USGS observed event')).toBeVisible();
+  await expect(page.locator('#event-detail-title')).toHaveText(
+    'Browser Fixture Ridge'
+  );
+  await expect(page.locator('#detail-magnitude')).toHaveText('M6.4');
+  await expect(page.locator('#detail-depth')).toHaveText('18.4 km');
+  await expect(page.locator('#detail-source')).toHaveAttribute(
+    'href',
+    'https://earthquake.usgs.gov/earthquakes/eventpage/test-fixture-ridge'
+  );
+  browser.assertClean();
+});
+
+test('a filter with no matching observations renders an explicit empty state', async ({
+  page,
+}) => {
+  const browser = await openAtlas(page);
+
+  await page.locator('#place-search').fill('No fixture has this place');
+
+  await expect(page.locator('#result-count')).toHaveText('0 results');
+  await expect(page.locator('#summary-count')).toHaveText('0');
+  await expect(page.locator('#event-list')).toHaveText(
+    'No observed events match this exact window.'
+  );
+  await expect(page.locator('#focus-strongest')).toBeDisabled();
+  browser.assertClean();
+});
+
+test('the timeline scrubber responds to keyboard navigation', async ({
+  page,
+}) => {
+  const browser = await openAtlas(page);
+  const scrubber = page.locator('#timeline-scrubber');
+
+  await expect(scrubber).toBeEnabled();
+  await expect(scrubber).toHaveValue('29');
+  await scrubber.focus();
+  await scrubber.press('Home');
+
+  await expect(scrubber).toHaveValue('0');
+  await expect(page.locator('#timeline-date')).toHaveText('Fri, Jul 17, 2026');
+  await expect(page.locator('#event-list')).toContainText(
+    'Keyboard Fixture Coast'
+  );
+
+  await scrubber.press('ArrowRight');
+  await expect(scrubber).toHaveValue('1');
+  await expect(page.locator('#timeline-date')).toHaveText('Sat, Jul 18, 2026');
+  browser.assertClean();
+});
+
+test('a failed live request exposes the committed fallback as fallback mode', async ({
+  page,
+}) => {
+  const browser = await openAtlas(page, { liveFeed: 'unavailable' });
+
+  await expect(page.locator('#feed-state')).toHaveAttribute(
+    'data-tone',
+    'fallback'
+  );
+  await expect(page.locator('#feed-label')).toHaveText('Fallback snapshot');
+  await expect(page.locator('#feed-detail')).toContainText(
+    'Significant events only · retrieved'
+  );
+  await expect(page.locator('#panel-notice')).toHaveText(
+    'The live monthly feed is unavailable. The map is showing a narrower, committed snapshot of significant events only.'
+  );
+  await expect(page.locator('.source-dock')).toContainText('Observed data');
+  browser.assertClean();
+});

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,12 @@
+# Browser fixtures
+
+`usgs-month.geojson` is a synthetic, test-only payload shaped like the public
+USGS monthly GeoJSON feed. Its places and event IDs are deliberately labeled as
+fixtures. It must never be copied into `static/data`, presented as an observed
+earthquake record, or used to refresh the repository's provenance-backed USGS
+fallback snapshot.
+
+Browser tests intercept the live feed with these fixed bytes and replace the
+remote basemap style with an empty local response. Any other external browser
+request is recorded and aborted so the suite remains deterministic and
+offline-safe.

--- a/tests/fixtures/usgs-month.geojson
+++ b/tests/fixtures/usgs-month.geojson
@@ -1,0 +1,97 @@
+{
+  "type": "FeatureCollection",
+  "metadata": {
+    "generated": 1786795200000,
+    "title": "Synthetic browser-test earthquake fixture"
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "id": "test-fixture-ridge",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-149.9, 61.2, 18.4]
+      },
+      "properties": {
+        "mag": 6.4,
+        "place": "Browser Fixture Ridge",
+        "time": 1786795200000,
+        "updated": 1786795500000,
+        "felt": 42,
+        "sig": 630,
+        "alert": "green",
+        "tsunami": 0,
+        "status": "reviewed",
+        "magType": "mw",
+        "title": "M 6.4 - Browser Fixture Ridge",
+        "url": "https://earthquake.usgs.gov/earthquakes/eventpage/test-fixture-ridge"
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "test-fixture-basin",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [139.7, 35.6, 320]
+      },
+      "properties": {
+        "mag": 5.1,
+        "place": "Browser Fixture Basin",
+        "time": 1786622400000,
+        "updated": 1786622700000,
+        "felt": null,
+        "sig": 410,
+        "alert": null,
+        "tsunami": 0,
+        "status": "automatic",
+        "magType": "mww",
+        "title": "M 5.1 - Browser Fixture Basin",
+        "url": "https://earthquake.usgs.gov/earthquakes/eventpage/test-fixture-basin"
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "test-fixture-shelf",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [178.1, -38.7, 44]
+      },
+      "properties": {
+        "mag": 4.3,
+        "place": "Browser Fixture Shelf",
+        "time": 1785931200000,
+        "updated": 1785931500000,
+        "felt": 3,
+        "sig": 280,
+        "alert": null,
+        "tsunami": 0,
+        "status": "reviewed",
+        "magType": "mb",
+        "title": "M 4.3 - Browser Fixture Shelf",
+        "url": "https://earthquake.usgs.gov/earthquakes/eventpage/test-fixture-shelf"
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "test-fixture-coast",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-72.4, -36.1, 55]
+      },
+      "properties": {
+        "mag": 3.8,
+        "place": "Keyboard Fixture Coast",
+        "time": 1784289600000,
+        "updated": 1784289900000,
+        "felt": 1,
+        "sig": 190,
+        "alert": null,
+        "tsunami": 0,
+        "status": "reviewed",
+        "magType": "ml",
+        "title": "M 3.8 - Keyboard Fixture Coast",
+        "url": "https://earthquake.usgs.gov/earthquakes/eventpage/test-fixture-coast"
+      }
+    }
+  ]
+}

--- a/tests/support/atlas-page.mjs
+++ b/tests/support/atlas-page.mjs
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+
+const liveFeedUrl =
+  'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson';
+const basemapStyleUrl = 'https://tiles.openfreemap.org/styles/fiord';
+const liveFixture = await readFile(
+  new URL('../fixtures/usgs-month.geojson', import.meta.url),
+  'utf8'
+);
+const emptyBasemapStyle = JSON.stringify({
+  version: 8,
+  name: 'Offline browser-test style',
+  sources: {},
+  layers: [],
+});
+
+export async function openAtlas(page, { liveFeed = 'fixture' } = {}) {
+  const pageErrors = [];
+  const externalRequests = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+
+  await page.route('**/*', async (route) => {
+    const requestUrl = new URL(route.request().url());
+
+    if (requestUrl.origin === 'http://127.0.0.1:4173') {
+      await route.continue();
+      return;
+    }
+
+    if (requestUrl.href === liveFeedUrl) {
+      if (liveFeed === 'fixture') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/geo+json',
+          body: liveFixture,
+        });
+      } else {
+        await route.abort('failed');
+      }
+      return;
+    }
+
+    if (requestUrl.href === basemapStyleUrl) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: emptyBasemapStyle,
+      });
+      return;
+    }
+
+    if (['http:', 'https:'].includes(requestUrl.protocol)) {
+      externalRequests.push(requestUrl.href);
+    }
+    await route.abort('blockedbyclient');
+  });
+
+  await page.goto('/');
+  await expect(page.locator('#feed-label')).not.toHaveText(
+    'Connecting to USGS'
+  );
+  await page.waitForLoadState('networkidle');
+
+  return {
+    assertClean() {
+      expect(externalRequests, 'unexpected external browser requests').toEqual(
+        []
+      );
+      expect(pageErrors, 'uncaught browser errors').toEqual([]);
+    },
+  };
+}

--- a/tests/support/atlas-page.mjs
+++ b/tests/support/atlas-page.mjs
@@ -1,6 +1,8 @@
 import { expect } from '@playwright/test';
 import { readFile } from 'node:fs/promises';
 
+import { atlasTestOrigin } from './test-server.mjs';
+
 const liveFeedUrl =
   'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_month.geojson';
 const basemapStyleUrl = 'https://tiles.openfreemap.org/styles/fiord';
@@ -8,6 +10,17 @@ const liveFixture = await readFile(
   new URL('../fixtures/usgs-month.geojson', import.meta.url),
   'utf8'
 );
+const revisedFixturePayload = JSON.parse(liveFixture);
+const revisedEvent = revisedFixturePayload.features.find(
+  ({ id }) => id === 'test-fixture-ridge'
+);
+revisedFixturePayload.metadata.generated += 60_000;
+revisedEvent.properties.mag = 6.7;
+revisedEvent.properties.place = 'Revised Browser Fixture Ridge';
+revisedEvent.properties.updated += 60_000;
+revisedEvent.properties.felt = 84;
+revisedEvent.properties.title = 'M 6.7 - Revised Browser Fixture Ridge';
+const revisedFixture = JSON.stringify(revisedFixturePayload);
 const emptyBasemapStyle = JSON.stringify({
   version: 8,
   name: 'Offline browser-test style',
@@ -18,22 +31,28 @@ const emptyBasemapStyle = JSON.stringify({
 export async function openAtlas(page, { liveFeed = 'fixture' } = {}) {
   const pageErrors = [];
   const externalRequests = [];
+  let liveRequestCount = 0;
   page.on('pageerror', (error) => pageErrors.push(error.message));
 
   await page.route('**/*', async (route) => {
     const requestUrl = new URL(route.request().url());
 
-    if (requestUrl.origin === 'http://127.0.0.1:4173') {
+    if (requestUrl.origin === atlasTestOrigin) {
       await route.continue();
       return;
     }
 
     if (requestUrl.href === liveFeedUrl) {
-      if (liveFeed === 'fixture') {
+      if (liveFeed === 'fixture' || liveFeed === 'revised-on-refresh') {
+        const body =
+          liveFeed === 'revised-on-refresh' && liveRequestCount > 0
+            ? revisedFixture
+            : liveFixture;
+        liveRequestCount += 1;
         await route.fulfill({
           status: 200,
           contentType: 'application/geo+json',
-          body: liveFixture,
+          body,
         });
       } else {
         await route.abort('failed');
@@ -63,6 +82,9 @@ export async function openAtlas(page, { liveFeed = 'fixture' } = {}) {
   await page.waitForLoadState('networkidle');
 
   return {
+    get liveRequestCount() {
+      return liveRequestCount;
+    },
     assertClean() {
       expect(externalRequests, 'unexpected external browser requests').toEqual(
         []

--- a/tests/support/serve-dist.mjs
+++ b/tests/support/serve-dist.mjs
@@ -1,0 +1,52 @@
+import { createServer } from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const host = '127.0.0.1';
+const port = Number(process.env.ATLAS_TEST_PORT || 4173);
+const distDirectory = fileURLToPath(new URL('../../dist/', import.meta.url));
+const distPrefix = `${resolve(distDirectory)}${sep}`;
+const contentTypes = new Map([
+  ['.css', 'text/css; charset=utf-8'],
+  ['.geojson', 'application/geo+json; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.ico', 'image/x-icon'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.webmanifest', 'application/manifest+json; charset=utf-8'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const requestUrl = new URL(request.url || '/', `http://${host}:${port}`);
+    const pathname =
+      requestUrl.pathname === '/' ? '/index.html' : requestUrl.pathname;
+    const filename = resolve(distDirectory, `.${decodeURIComponent(pathname)}`);
+
+    if (!filename.startsWith(distPrefix) || !(await stat(filename)).isFile()) {
+      response.writeHead(404).end('Not found');
+      return;
+    }
+
+    const body = await readFile(filename);
+    response.writeHead(200, {
+      'Cache-Control': 'no-store',
+      'Content-Type':
+        contentTypes.get(extname(filename)) || 'application/octet-stream',
+    });
+    response.end(body);
+  } catch {
+    response.writeHead(404).end('Not found');
+  }
+});
+
+server.listen(port, host);
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => server.close(() => process.exit(0)));
+}

--- a/tests/support/serve-dist.mjs
+++ b/tests/support/serve-dist.mjs
@@ -3,8 +3,10 @@ import { readFile, stat } from 'node:fs/promises';
 import { extname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const host = '127.0.0.1';
-const port = Number(process.env.ATLAS_TEST_PORT || 4173);
+import { ATLAS_TEST_HOST, atlasTestPort } from './test-server.mjs';
+
+const host = ATLAS_TEST_HOST;
+const port = atlasTestPort;
 const distDirectory = fileURLToPath(new URL('../../dist/', import.meta.url));
 const distPrefix = `${resolve(distDirectory)}${sep}`;
 const contentTypes = new Map([

--- a/tests/support/test-server.mjs
+++ b/tests/support/test-server.mjs
@@ -1,0 +1,18 @@
+export const ATLAS_TEST_HOST = '127.0.0.1';
+export const DEFAULT_ATLAS_TEST_PORT = 4173;
+
+export function getAtlasTestPort(value = process.env.ATLAS_TEST_PORT) {
+  const port =
+    value == null || value === '' ? DEFAULT_ATLAS_TEST_PORT : Number(value);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new Error('ATLAS_TEST_PORT must be an integer from 1 through 65535');
+  }
+  return port;
+}
+
+export function getAtlasTestOrigin(value = process.env.ATLAS_TEST_PORT) {
+  return `http://${ATLAS_TEST_HOST}:${getAtlasTestPort(value)}`;
+}
+
+export const atlasTestPort = getAtlasTestPort();
+export const atlasTestOrigin = getAtlasTestOrigin();

--- a/tests/test-server.test.mjs
+++ b/tests/test-server.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULT_ATLAS_TEST_PORT,
+  getAtlasTestOrigin,
+  getAtlasTestPort,
+} from './support/test-server.mjs';
+
+test('uses one validated browser-test server contract', () => {
+  assert.equal(getAtlasTestPort(null), DEFAULT_ATLAS_TEST_PORT);
+  assert.equal(getAtlasTestPort('44173'), 44_173);
+  assert.equal(getAtlasTestOrigin('44173'), 'http://127.0.0.1:44173');
+
+  for (const invalid of ['0', '65536', '4.5', 'not-a-port']) {
+    assert.throws(() => getAtlasTestPort(invalid), /ATLAS_TEST_PORT/);
+  }
+});


### PR DESCRIPTION
## Summary

Adds deterministic browser-level coverage for the full-screen Earthquake Atlas without changing production behavior or observational data.

- Exercises event selection and the observed-event detail panel.
- Verifies revised USGS data refreshes an already selected event.
- Verifies the explicit empty-filter result state.
- Verifies keyboard navigation on the timeline scrubber.
- Forces the live-feed failure path and verifies the committed fallback is clearly labeled.
- Runs the production `dist` bundle through one validated local static-server contract.
- Intercepts the USGS feed with a fixed synthetic fixture and replaces the remote basemap style with an empty response.
- Aborts and reports every other external browser request, keeping the suite offline-safe.
- Uses `ATLAS_TEST_PORT` consistently for the server, Playwright readiness URL, and browser base URL.
- Installs Chromium and runs the browser gate in CI once Actions are enabled.

## Evidence boundary

The synthetic GeoJSON exists only under `tests/fixtures`, uses fixture-labeled IDs and places, and is documented as non-observational test data. It does not alter `static/data`, the provenance-backed USGS fallback snapshot, or application code. The fallback-mode test uses the committed snapshot and receipt and verifies both visible fallback status and the narrower-significant-events notice.

## Dependency order

Atlas PR #178 merged first as `3b6c0526625e152768d3196bd4fdc260fcd427ea`. This branch was rebased onto that exact `main` tree, now targets `main` directly, and remains byte-identical to the previously reviewed browser-coverage tree.

## Validation at exact head `17426716eed7813ba5ee87f6d3fb7b1750be0cfa`

- `npm ci`: clean install, 0 vulnerabilities reported
- `npm test`: format checks pass; 21 unit/semantic/server tests pass; Parcel production build succeeds; 4 emitted-artifact tests pass
- `ATLAS_TEST_PORT=44173 npm run test:browser`: 5 Chromium tests pass
- `npm audit --audit-level=low`: 0 vulnerabilities

GitHub Actions are disabled for this repository (tracked in #170), so the exact pushed head has no hosted check runs. The complete repository-defined local gate passed after the rebase.

## Review notes

The current configuration covers the prior `ATLAS_TEST_PORT` review finding through a shared server/base-URL contract and an explicit regression test. Its GitHub thread remains unresolved because thread resolution is a separate review action.